### PR TITLE
Fix problem with 64-bit integer

### DIFF
--- a/src/redisclient/impl/redisparser.cpp
+++ b/src/redisclient/impl/redisparser.cpp
@@ -423,7 +423,7 @@ std::pair<size_t, RedisParser::ParseResult> RedisParser::parseChunk(const char *
                 {
                     // TODO optimize me
                     std::string tmp(buf.begin(), buf.end());
-                    long int value = strtol(tmp.c_str(), 0, 10);
+                    int64_t value = strtoll(tmp.c_str(), 0, 10);
 
                     buf.clear();
 

--- a/src/redisclient/impl/redisvalue.cpp
+++ b/src/redisclient/impl/redisvalue.cpp
@@ -15,7 +15,7 @@ RedisValue::RedisValue()
 {
 }
 
-RedisValue::RedisValue(int i)
+RedisValue::RedisValue(int64_t i)
     : value(i), error(false)
 {
 }
@@ -61,9 +61,9 @@ std::vector<char> RedisValue::toByteArray() const
     return castTo<std::vector<char> >();
 }
 
-int RedisValue::toInt() const
+int64_t RedisValue::toInt() const
 {
-    return castTo<int>();
+    return castTo<int64_t>();
 }
 
 std::string RedisValue::inspect() const
@@ -133,7 +133,7 @@ bool RedisValue::isNull() const
 
 bool RedisValue::isInt() const
 {
-    return typeEq<int>();
+    return typeEq<int64_t>();
 }
 
 bool RedisValue::isString() const

--- a/src/redisclient/redisvalue.h
+++ b/src/redisclient/redisvalue.h
@@ -17,7 +17,7 @@ public:
     struct ErrorTag {};
 
     REDIS_CLIENT_DECL RedisValue();
-    REDIS_CLIENT_DECL RedisValue(int i);
+    REDIS_CLIENT_DECL RedisValue(int64_t i);
     REDIS_CLIENT_DECL RedisValue(const char *s);
     REDIS_CLIENT_DECL RedisValue(const std::string &s);
     REDIS_CLIENT_DECL RedisValue(const std::vector<char> &buf);
@@ -34,7 +34,7 @@ public:
     
     // Return the value as a std::vector<RedisValue> if 
     // type is an int; otherwise returns 0.
-    REDIS_CLIENT_DECL int toInt() const;
+    REDIS_CLIENT_DECL int64_t toInt() const;
     
     // Return the value as an array if type is an array;
     // otherwise returns an empty array.
@@ -79,7 +79,7 @@ private:
     };
 
 
-    boost::variant<NullTag, int, std::vector<char>, std::vector<RedisValue> > value;
+    boost::variant<NullTag, int64_t, std::vector<char>, std::vector<RedisValue> > value;
     bool error;
 };
 


### PR DESCRIPTION
Redis support 64-bit integer, but RedisValue return int. 
This patch fix problem.