### PR TITLE
Set option "no delay" only for TCP sockets

### DIFF
--- a/amalgamated/redisclient.cpp
+++ b/amalgamated/redisclient.cpp
@@ -362,7 +362,8 @@ void RedisClientImpl::handleAsyncConnect(const boost::system::error_code &ec,
 {
     if( !ec )
     {
-        socket.set_option(boost::asio::ip::tcp::no_delay(true));
+        boost::system::error_code ec2; // Ignore errors in set_option
+        socket.set_option(boost::asio::ip::tcp::no_delay(true), ec2);
         state = State::Connected;
         handler(true, std::string());
         processMessage();
@@ -1224,12 +1225,7 @@ bool RedisSyncClient::connect(const boost::asio::local::stream_protocol::endpoin
 
     if( !ec )
     {
-        pimpl->socket.set_option(boost::asio::ip::tcp::no_delay(true), ec);
-
-        if( !ec )
-        {
-            pimpl->socket.connect(endpoint, ec);
-        }
+        pimpl->socket.connect(endpoint, ec);
     }
 
     if( !ec )

--- a/src/redisclient/impl/redisclientimpl.cpp
+++ b/src/redisclient/impl/redisclientimpl.cpp
@@ -162,7 +162,8 @@ void RedisClientImpl::handleAsyncConnect(const boost::system::error_code &ec,
 {
     if( !ec )
     {
-        socket.set_option(boost::asio::ip::tcp::no_delay(true));
+        boost::system::error_code ec2; // Ignore errors in set_option
+        socket.set_option(boost::asio::ip::tcp::no_delay(true), ec2);
         state = State::Connected;
         handler(true, std::string());
         processMessage();

--- a/src/redisclient/impl/redissyncclient.cpp
+++ b/src/redisclient/impl/redissyncclient.cpp
@@ -73,12 +73,7 @@ bool RedisSyncClient::connect(const boost::asio::local::stream_protocol::endpoin
 
     if( !ec )
     {
-        pimpl->socket.set_option(boost::asio::ip::tcp::no_delay(true), ec);
-
-        if( !ec )
-        {
-            pimpl->socket.connect(endpoint, ec);
-        }
+        pimpl->socket.connect(endpoint, ec);
     }
 
     if( !ec )


### PR DESCRIPTION
UNIX sockets do not support this option.