### PR TITLE
Fix psubscribe bug: Psusbcribe handlers are not triggered when an event is received.

### DIFF
--- a/src/redisclient/impl/redisclientimpl.cpp
+++ b/src/redisclient/impl/redisclientimpl.cpp
@@ -102,13 +102,13 @@ void RedisClientImpl::doProcessMessage(RedisValue v)
             const RedisValue &command   = result[0];
             const RedisValue &queueName = result[(resultSize == 3)?1:2];
             const RedisValue &value     = result[(resultSize == 3)?2:3];
-            const RedisValue &pattern   = (resultSize == 4) ? result[1] : "";
+            const RedisValue &pattern   = (resultSize == 4) ? result[1] : queueName;
 
             std::string cmd = command.toString();
 
             if( cmd == "message" || cmd == "pmessage" )
             {
-                SingleShotHandlersMap::iterator it = singleShotMsgHandlers.find(queueName.toString());
+                SingleShotHandlersMap::iterator it = singleShotMsgHandlers.find(pattern.toString());
                 if( it != singleShotMsgHandlers.end() )
                 {
                     strand.post(std::bind(it->second, value.toByteArray()));
@@ -116,7 +116,7 @@ void RedisClientImpl::doProcessMessage(RedisValue v)
                 }
 
                 std::pair<MsgHandlersMap::iterator, MsgHandlersMap::iterator> pair =
-                        msgHandlers.equal_range(queueName.toString());
+                        msgHandlers.equal_range(pattern.toString());
                 for(MsgHandlersMap::iterator handlerIt = pair.first;
                     handlerIt != pair.second; ++handlerIt)
                 {


### PR DESCRIPTION
psubscribe doesn't work. To observe this bug, comment out lines 135 and 136 of examples/async_pubsub.cpp : "Client::onMessage" is never called. With this commit, the right handler is called.