### PR TITLE
FIx multi thread calls asyncWrite concurrently.

### DIFF
--- a/src/redisclient/impl/redisclientimpl.cpp
+++ b/src/redisclient/impl/redisclientimpl.cpp
@@ -12,6 +12,10 @@
 
 #include "redisclientimpl.h"
 
+#ifdef __APPLE__
+typedef suseconds_t __suseconds_t;
+#endif
+
 namespace
 {
     static const char crlf[] = {'\r', '\n'};

--- a/src/redisclient/impl/redisclientimpl.cpp
+++ b/src/redisclient/impl/redisclientimpl.cpp
@@ -360,8 +360,9 @@ void RedisClientImpl::asyncWrite(const boost::system::error_code &ec, size_t)
         std::swap(dataQueued, dataWrited);
 
         boost::asio::async_write(socket, buffers,
-                std::bind(&RedisClientImpl::asyncWrite, shared_from_this(),
-                    std::placeholders::_1, std::placeholders::_2));
+                strand.wrap(
+                    std::bind(&RedisClientImpl::asyncWrite, shared_from_this(),
+                        std::placeholders::_1, std::placeholders::_2)));
     }
 }
 


### PR DESCRIPTION
    Multiple thread may excute asyncWrite at the same time.
    1. Thread A request quite a lot RedisAsyncClient::command, all the
    command post to RedisClientImpl::strand.
    2. Thread B execute commands in strand one by one. The first asyncWrite
    swap dataWrited and dataQueued, so other doAsyncCommand won't enter
    asyncWrite.
    3. the first asyncWrite call ends with a boost::asio::async_write, and
    left a later asyncWrite as handler.
    4. boost::asio::async_write complete, thread C excute the handler
    asyncWrite, clear dataWrited.
    5. Now thread B execute doAsyncCommand, and find dataWrited was empty,
    so it enters asyncWrite concurrently!